### PR TITLE
Update fields.json

### DIFF
--- a/spectateur/static/fields.json
+++ b/spectateur/static/fields.json
@@ -2749,20 +2749,6 @@
 "name": "available virtual memory", 
 "extensible": true
 }, 
-"exploitability": {
-"multiple": true, 
-"valueType": "enum", 
-"values": [
-"high", 
-"normal", 
-"low", 
-"none", 
-"unknown", 
-"error"
-], 
-"name": "exploitability", 
-"extensible": true
-}, 
 "startup_time": {
 "multiple": true, 
 "valueType": "number", 


### PR DESCRIPTION
exploitability is a sensitive field and it isn't honored by the api anyway. It will return scrubbed but results won't reflect what you ask.
